### PR TITLE
feat: add sticky section index with active links

### DIFF
--- a/script.js
+++ b/script.js
@@ -8,6 +8,23 @@ document.addEventListener('DOMContentLoaded', () => {
   // sections inside the content area (exclude hero)
   const sections = document.querySelectorAll('.sections-content section');
 
+  // make TOC links clickable with smooth scroll and active state
+  navLinks.forEach((link) => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const target = document.querySelector(link.getAttribute('href'));
+      if (target) {
+        target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      }
+      navLinks.forEach((l) => {
+        l.classList.remove('active');
+        l.removeAttribute('aria-current');
+      });
+      link.classList.add('active');
+      link.setAttribute('aria-current', 'page');
+    });
+  });
+
   // Measure header height for sticky offset and expose via CSS variable
   if (header) {
     const setHeaderHeight = () => root.style.setProperty('--header-h', `${header.offsetHeight}px`);
@@ -58,7 +75,7 @@ document.addEventListener('DOMContentLoaded', () => {
           });
         }
       });
-    }, { threshold: 0.6 });
+    }, { threshold: 0.3 });
 
     sections.forEach((section) => {
       sectionObserver.observe(section);

--- a/styles.css
+++ b/styles.css
@@ -15,6 +15,10 @@
 }
 
 /* Base styles */
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   background-color: var(--bg-color);
@@ -123,6 +127,7 @@ h3 {
 
 .content-section:first-of-type {
   border-top: none;
+  padding-top: 0;
 }
 
 .section-image img {
@@ -159,7 +164,7 @@ h3 {
 .section-start {
   border: 0;
   border-top: 1px solid #e7e7e7;
-  margin: 40px 0 0;
+  margin: 0;
 }
 
 .sections-grid {
@@ -169,6 +174,7 @@ h3 {
   max-width: var(--container);
   margin: 0 auto;
   align-items: start;
+  padding-top: 4rem;
 }
 
 .section-index {


### PR DESCRIPTION
## Summary
- align section index with first section and keep it sticky until the end
- highlight table of contents items on click and during scroll
- enable smooth scrolling to each section anchor

## Testing
- `npx eslint .`


------
https://chatgpt.com/codex/tasks/task_e_689b6fa60e688329a89139dfbec21669