### PR TITLE
fix: sync section index with first section

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,14 +1,10 @@
-// Updated IntersectionObserver logic for TOC visibility and section highlighting
+// IntersectionObserver logic for TOC section highlighting
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.documentElement;
-  const footer = document.querySelector('footer');
   const header = document.querySelector('.site-header');
   const navLinks = document.querySelectorAll('.section-index a');
   // sections inside the content area (exclude hero)
   const sections = document.querySelectorAll('.sections-content section');
-
-  // show TOC by default
-  root.classList.add('toc--visible');
 
   // make TOC links clickable with smooth scroll and active state
   navLinks.forEach((link) => {
@@ -32,20 +28,6 @@ document.addEventListener('DOMContentLoaded', () => {
     const setHeaderHeight = () => root.style.setProperty('--header-h', `${header.offsetHeight}px`);
     setHeaderHeight();
     window.addEventListener('resize', setHeaderHeight);
-  }
-
-  /*
-   * Keep the table of contents visible with the sections and hide it when the
-   * footer enters the viewport so it doesn't overlap.
-   */
-  if (footer) {
-    new IntersectionObserver(([entry]) => {
-      if (entry.isIntersecting) {
-        root.classList.remove('toc--visible');
-      } else {
-        root.classList.add('toc--visible');
-      }
-    }, { threshold: 0 }).observe(footer);
   }
 
   // Highlight active section in the TOC

--- a/styles.css
+++ b/styles.css
@@ -169,21 +169,22 @@ h3 {
 
 .sections-grid {
   max-width: var(--container);
-  margin-left: calc(var(--toc-w) + var(--gap) + 2rem);
-  padding-top: 4rem;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: row;
+  gap: var(--gap);
+  padding: 4rem 2rem 0;
 }
 
 .section-index {
-  position: fixed;
+  position: sticky;
   top: calc(var(--header-h, 0px) + var(--sticky-offset));
-  left: 2rem;
   width: var(--toc-w);
-  visibility: hidden;
+  flex-shrink: 0;
 }
 
-/* When sentinel has been passed, show the TOC */
-.toc--visible .section-index {
-  visibility: visible;
+.sections-content {
+  flex: 1;
 }
 
 /* Ensure content doesn't overlap the TOC */
@@ -271,7 +272,8 @@ footer {
     display: none !important;
   }
   .sections-grid {
-    margin-left: 0;
+    flex-direction: column;
+    padding: 4rem 1rem 0;
   }
   .site-header {
     flex-direction: column;


### PR DESCRIPTION
## Summary
- align section index with first content section via CSS `position: sticky`
- simplify TOC script to remove hero/footer observers

## Testing
- `npx -y stylelint styles.css`
- `npx eslint script.js`


------
https://chatgpt.com/codex/tasks/task_e_689c96a62164832988c3500018d7a06c